### PR TITLE
Update Cania11y on GitHub link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
 			<li><a href="{{ site.url }}/clients/">Compare software combinations</a></li>
 			<li><a href="{{ site.url }}/scoreboard/">software combination Support Scoreboard</a></li>
 			<li><a href="{{ site.url }}/api/data.json">Data available in JSON</a></li>
-			<li><a href="https://github.com/lemnis/cania11y">Cania11y on GitHub</a></li>
+			<li><a href="https://github.com/lemnis/caniemail">Cania11y on GitHub</a></li>
 			<li><a href="https://embed.cania11y.com">The Cania11y Embed</a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
The Cania11y on GitHub was pointing to the old repository.

This commit updates the link to the new repository.